### PR TITLE
Update sophos checks to extend the usage of snmpv3

### DIFF
--- a/check_sophos_xg_disk.pl
+++ b/check_sophos_xg_disk.pl
@@ -68,31 +68,30 @@ $mp->add_arg(
 );
 
 $mp->add_arg(
-    spec     => 'username|u=s',
-    help     => 'security name',
-    # required => 1
+    spec => 'username|u=s',
+    help => 'Username for SNMPv3',
 );
 
 $mp->add_arg(
-    spec     => 'authprotocol|a=s',
-    help     => 'Authentication protocol (MD5|SHA|SHA-224|SHA-256|SHA-384|SHA-512)',
-    # required => 1
+    spec => 'authpassword|A=s',
+    help => 'Authentication protocol password',
 );
 
 $mp->add_arg(
-    spec     => 'authpassphrase|A=s',
-    help     => 'Authentication protocol pass phrase',
-    # required => 1
+    spec    => 'authprotocol|a=s',
+    help    => 'Authentication protocol: MD5, SHA, SHA-224, SHA-256, SHA-384, SHA-512 (Default: MD5)',
+    default => 'md5',
 );
 
 $mp->add_arg(
-    spec     => 'privprotocol|x=s',
-    help     => 'Privacy protocol (DES|AES)',
+    spec => 'privpassword|X=s',
+    help => 'privacy protocol password',
 );
 
 $mp->add_arg(
-    spec     => 'privpassphrase|X=s',
-    help     => 'privacy protocol pass phrase',
+    spec    => 'privprotocol|x=s',
+    help    => 'Privacy protocol: DES, AES (Default: DES)',
+    default => 'des',
 );
 
 $mp->add_arg(
@@ -111,27 +110,47 @@ $mp->add_arg(
     default => 0,
 );
 
+$mp->add_arg(
+    spec    => 'verbose',
+    help    => 'Print verbose/debug information',
+    default => 0,
+);
+
 $mp->getopts;
 
-#Open SNMP v3 Session
-=begin comment
-my ($session, $error) = Net::SNMP->session(
-    -hostname => $mp->opts->hostname,
-    -version => 'snmpv3',
-    -username => $mp->opts->username,
-    -authprotocol => $mp->opts->authprotocol,
-    -authpassword => $mp->opts->authpassphrase,
-    -privprotocol => $mp->opts->privprotocol,
-    -privpassword => $mp->opts->privpassphrase,
-);
-=cut
-
-#Open SNMP Session
-my ($session, $error) = Net::SNMP->session(
-    -hostname => $mp->opts->hostname,
-    -version => 'snmpv2c',
-    -community => $mp->opts->community,
-);
+my ($session, $error);
+if (defined($mp->opts->username) && defined($mp->opts->authpassword)) {
+    # SNMPv3 login
+    verb('SNMPv3 login');
+    if (!defined($mp->opts->privpassword)) {
+        verb('SNMPv3 AuthNoPriv login : %s, %s', $mp->opts->username, $mp->opts->authprotocol);
+        ($session, $error) = Net::SNMP->session(
+            -hostname => $mp->opts->hostname,
+            -version => 'snmpv3',
+            -username => $mp->opts->username,
+            -authprotocol => $mp->opts->authprotocol,
+            -authpassword => $mp->opts->authpassword,
+        );
+    } else {
+        verb('SNMPv3 AuthPriv login : %s, %s, %s', ${mp->opts->username}, ${mp->opts->authprotocol}, ${mp->opts->privprotocol});
+        ($session, $error) = Net::SNMP->session(
+            -hostname => $mp->opts->hostname,
+            -version => 'snmpv3',
+            -username => $mp->opts->username,
+            -authprotocol => $mp->opts->authprotocol,
+            -authpassword => $mp->opts->authpassword,
+            -privprotocol => $mp->opts->privprotocol,
+            -privpassword => $mp->opts->privpassword,
+        );
+    }
+} else {
+  verb('SNMP v2c login');
+  ($session, $error) = Net::SNMP->session(
+      -hostname => $mp->opts->hostname,
+      -version => 'snmpv2c',
+      -community => $mp->opts->community,
+  );
+}
 
 if (!defined($session)) {
     wrap_exit(UNKNOWN, $error)
@@ -298,6 +317,14 @@ sub check
                 $capacity_usage,
             )
         );
+    }
+}
+
+sub verb
+{
+    my $t = shift;
+    if ($mp->opts->verbose) {
+      printf($t . "\n", @_);
     }
 }
 

--- a/check_sophos_xg_disk.pl
+++ b/check_sophos_xg_disk.pl
@@ -132,7 +132,7 @@ if (defined($mp->opts->username) && defined($mp->opts->authpassword)) {
             -authpassword => $mp->opts->authpassword,
         );
     } else {
-        verb('SNMPv3 AuthPriv login : %s, %s, %s', ${mp->opts->username}, ${mp->opts->authprotocol}, ${mp->opts->privprotocol});
+        verb('SNMPv3 AuthPriv login : %s, %s, %s', $mp->opts->username, $mp->opts->authprotocol, $mp->opts->privprotocol);
         ($session, $error) = Net::SNMP->session(
             -hostname => $mp->opts->hostname,
             -version => 'snmpv3',

--- a/check_sophos_xg_disk.pl
+++ b/check_sophos_xg_disk.pl
@@ -113,7 +113,7 @@ $mp->add_arg(
 
 $mp->getopts;
 
-#Open SNMP v3 Session 
+#Open SNMP v3 Session
 =begin comment
 my ($session, $error) = Net::SNMP->session(
     -hostname => $mp->opts->hostname,

--- a/check_sophos_xg_disk.pl
+++ b/check_sophos_xg_disk.pl
@@ -68,6 +68,34 @@ $mp->add_arg(
 );
 
 $mp->add_arg(
+    spec     => 'username|u=s',
+    help     => 'security name',
+    # required => 1
+);
+
+$mp->add_arg(
+    spec     => 'authprotocol|a=s',
+    help     => 'Authentication protocol (MD5|SHA|SHA-224|SHA-256|SHA-384|SHA-512)',
+    # required => 1
+);
+
+$mp->add_arg(
+    spec     => 'authpassphrase|A=s',
+    help     => 'Authentication protocol pass phrase',
+    # required => 1
+);
+
+$mp->add_arg(
+    spec     => 'privprotocol|x=s',
+    help     => 'Privacy protocol (DES|AES)',
+);
+
+$mp->add_arg(
+    spec     => 'privpassphrase|X=s',
+    help     => 'privacy protocol pass phrase',
+);
+
+$mp->add_arg(
     spec => 'warning=s',
     help => 'Allowed values are % of capacity or value in MB (Default: 80% or 20% if --free is set)',
 );
@@ -84,6 +112,19 @@ $mp->add_arg(
 );
 
 $mp->getopts;
+
+#Open SNMP v3 Session 
+=begin comment
+my ($session, $error) = Net::SNMP->session(
+    -hostname => $mp->opts->hostname,
+    -version => 'snmpv3',
+    -username => $mp->opts->username,
+    -authprotocol => $mp->opts->authprotocol,
+    -authpassword => $mp->opts->authpassphrase,
+    -privprotocol => $mp->opts->privprotocol,
+    -privpassword => $mp->opts->privpassphrase,
+);
+=cut
 
 #Open SNMP Session
 my ($session, $error) = Net::SNMP->session(

--- a/check_sophos_xg_info.pl
+++ b/check_sophos_xg_info.pl
@@ -115,7 +115,7 @@ if (defined($mp->opts->username) && defined($mp->opts->authpassword)) {
             -authpassword => $mp->opts->authpassword,
         );
     } else {
-        verb('SNMPv3 AuthPriv login : %s, %s, %s', ${mp->opts->username}, ${mp->opts->authprotocol}, ${mp->opts->privprotocol});
+        verb('SNMPv3 AuthPriv login : %s, %s, %s', $mp->opts->username, $mp->opts->authprotocol, $mp->opts->privprotocol);
         ($session, $error) = Net::SNMP->session(
             -hostname => $mp->opts->hostname,
             -version => 'snmpv3',

--- a/check_sophos_xg_info.pl
+++ b/check_sophos_xg_info.pl
@@ -60,60 +60,80 @@ $mp->add_arg(
 );
 
 $mp->add_arg(
-    spec => 'hostname|H=s',
-    help => 'Hostname or IP of the device with SNMP access enabled',
+    spec     => 'hostname|H=s',
+    help     => 'Hostname or IP of the device with SNMP access enabled',
     required => 1
 );
 
 $mp->add_arg(
-    spec     => 'username|u=s',
-    help     => 'security name',
-    # required => 1
+    spec => 'username|u=s',
+    help => 'Username for SNMPv3',
 );
 
 $mp->add_arg(
-    spec     => 'authprotocol|a=s',
-    help     => 'Authentication protocol (MD5|SHA|SHA-224|SHA-256|SHA-384|SHA-512)',
-    # required => 1
+    spec => 'authpassword|A=s',
+    help => 'Authentication protocol password',
 );
 
 $mp->add_arg(
-    spec     => 'authpassphrase|A=s',
-    help     => 'Authentication protocol pass phrase',
-    # required => 1
+    spec    => 'authprotocol|a=s',
+    help    => 'Authentication protocol: MD5, SHA, SHA-224, SHA-256, SHA-384, SHA-512 (Default: MD5)',
+    default => 'md5',
 );
 
 $mp->add_arg(
-    spec     => 'privprotocol|x=s',
-    help     => 'Privacy protocol (DES|AES)',
+    spec => 'privpassword|X=s',
+    help => 'privacy protocol password',
 );
 
 $mp->add_arg(
-    spec     => 'privpassphrase|X=s',
-    help     => 'privacy protocol pass phrase',
+    spec    => 'privprotocol|x=s',
+    help    => 'Privacy protocol: DES, AES (Default: DES)',
+    default => 'des',
+);
+
+$mp->add_arg(
+    spec    => 'verbose',
+    help    => 'Print verbose/debug information',
+    default => 0,
 );
 
 $mp->getopts;
 
-#Open SNMP v3 Session
-=begin comment
-my ($session, $error) = Net::SNMP->session(
-    -hostname => $mp->opts->hostname,
-    -version => 'snmpv3',
-    -username => $mp->opts->username,
-    -authprotocol => $mp->opts->authprotocol,
-    -authpassword => $mp->opts->authpassphrase,
-    -privprotocol => $mp->opts->privprotocol,
-    -privpassword => $mp->opts->privpassphrase,
-);
-=cut
 
-#Open SNMP Session
-my ($session, $error) = Net::SNMP->session(
-    -hostname => $mp->opts->hostname,
-    -version => 'snmpv2c',
-    -community => $mp->opts->community,
-);
+my ($session, $error);
+if (defined($mp->opts->username) && defined($mp->opts->authpassword)) {
+    # SNMPv3 login
+    verb('SNMPv3 login');
+    if (!defined($mp->opts->privpassword)) {
+        verb('SNMPv3 AuthNoPriv login : %s, %s', $mp->opts->username, $mp->opts->authprotocol);
+        ($session, $error) = Net::SNMP->session(
+            -hostname => $mp->opts->hostname,
+            -version => 'snmpv3',
+            -username => $mp->opts->username,
+            -authprotocol => $mp->opts->authprotocol,
+            -authpassword => $mp->opts->authpassword,
+        );
+    } else {
+        verb('SNMPv3 AuthPriv login : %s, %s, %s', ${mp->opts->username}, ${mp->opts->authprotocol}, ${mp->opts->privprotocol});
+        ($session, $error) = Net::SNMP->session(
+            -hostname => $mp->opts->hostname,
+            -version => 'snmpv3',
+            -username => $mp->opts->username,
+            -authprotocol => $mp->opts->authprotocol,
+            -authpassword => $mp->opts->authpassword,
+            -privprotocol => $mp->opts->privprotocol,
+            -privpassword => $mp->opts->privpassword,
+        );
+    }
+} else {
+  verb('SNMP v2c login');
+  ($session, $error) = Net::SNMP->session(
+      -hostname => $mp->opts->hostname,
+      -version => 'snmpv2c',
+      -community => $mp->opts->community,
+  );
+}
 
 if (!defined($session)) {
     wrap_exit(UNKNOWN, $error)
@@ -143,6 +163,14 @@ sub check
     $mp->add_message(OK, 'Firmware: ' . $result->{$sfosDeviceFWVersion});
     $mp->add_message(OK, 'Webcat: ' . $result->{$sfosWebcatVersion});
     $mp->add_message(OK, 'IPS: ' . $result->{$sfosIPSVersion});
+}
+
+sub verb
+{
+    my $t = shift;
+    if ($mp->opts->verbose) {
+      printf($t . "\n", @_);
+    }
 }
 
 sub wrap_exit

--- a/check_sophos_xg_info.pl
+++ b/check_sophos_xg_info.pl
@@ -95,7 +95,7 @@ $mp->add_arg(
 
 $mp->getopts;
 
-#Open SNMP v3 Session 
+#Open SNMP v3 Session
 =begin comment
 my ($session, $error) = Net::SNMP->session(
     -hostname => $mp->opts->hostname,

--- a/check_sophos_xg_info.pl
+++ b/check_sophos_xg_info.pl
@@ -61,11 +61,52 @@ $mp->add_arg(
 
 $mp->add_arg(
     spec => 'hostname|H=s',
-    help => '',
+    help => 'Hostname or IP of the device with SNMP access enabled',
     required => 1
 );
 
+$mp->add_arg(
+    spec     => 'username|u=s',
+    help     => 'security name',
+    # required => 1
+);
+
+$mp->add_arg(
+    spec     => 'authprotocol|a=s',
+    help     => 'Authentication protocol (MD5|SHA|SHA-224|SHA-256|SHA-384|SHA-512)',
+    # required => 1
+);
+
+$mp->add_arg(
+    spec     => 'authpassphrase|A=s',
+    help     => 'Authentication protocol pass phrase',
+    # required => 1
+);
+
+$mp->add_arg(
+    spec     => 'privprotocol|x=s',
+    help     => 'Privacy protocol (DES|AES)',
+);
+
+$mp->add_arg(
+    spec     => 'privpassphrase|X=s',
+    help     => 'privacy protocol pass phrase',
+);
+
 $mp->getopts;
+
+#Open SNMP v3 Session 
+=begin comment
+my ($session, $error) = Net::SNMP->session(
+    -hostname => $mp->opts->hostname,
+    -version => 'snmpv3',
+    -username => $mp->opts->username,
+    -authprotocol => $mp->opts->authprotocol,
+    -authpassword => $mp->opts->authpassphrase,
+    -privprotocol => $mp->opts->privprotocol,
+    -privpassword => $mp->opts->privpassphrase,
+);
+=cut
 
 #Open SNMP Session
 my ($session, $error) = Net::SNMP->session(

--- a/check_sophos_xg_license.pl
+++ b/check_sophos_xg_license.pl
@@ -81,37 +81,36 @@ $mp->add_arg(
 );
 
 $mp->add_arg(
-    spec => 'hostname|H=s',
-    help => 'Hostname or IP of the device with SNMP access enabled',
+    spec     => 'hostname|H=s',
+    help     => 'Hostname or IP of the device with SNMP access enabled',
     required => 1
 );
 
 $mp->add_arg(
-    spec     => 'username|u=s',
-    help     => 'security name',
-    # required => 1
+    spec => 'username|u=s',
+    help => 'Username for SNMPv3',
 );
 
 $mp->add_arg(
-    spec     => 'authprotocol|a=s',
-    help     => 'Authentication protocol (MD5|SHA|SHA-224|SHA-256|SHA-384|SHA-512)',
-    # required => 1
+    spec => 'authpassword|A=s',
+    help => 'Authentication protocol password',
 );
 
 $mp->add_arg(
-    spec     => 'authpassphrase|A=s',
-    help     => 'Authentication protocol pass phrase',
-    # required => 1
+    spec    => 'authprotocol|a=s',
+    help    => 'Authentication protocol: MD5, SHA, SHA-224, SHA-256, SHA-384, SHA-512 (Default: MD5)',
+    default => 'md5',
 );
 
 $mp->add_arg(
-    spec     => 'privprotocol|x=s',
-    help     => 'Privacy protocol (DES|AES)',
+    spec => 'privpassword|X=s',
+    help => 'privacy protocol password',
 );
 
 $mp->add_arg(
-    spec     => 'privpassphrase|X=s',
-    help     => 'privacy protocol pass phrase',
+    spec    => 'privprotocol|x=s',
+    help    => 'Privacy protocol: DES, AES (Default: DES)',
+    default => 'des',
 );
 
 $mp->add_arg(
@@ -147,6 +146,12 @@ $mp->add_arg(
     default => ['subscribed'],
 );
 
+$mp->add_arg(
+    spec    => 'verbose',
+    help    => 'Print verbose/debug information',
+    default => 0,
+);
+
 $mp->getopts;
 
 my @licenses_included;
@@ -175,25 +180,39 @@ foreach my $name (@licenses_included) {
     push(@licenses_to_check, $name);
 }
 
-#Open SNMP v3 Session
-=begin comment
-my ($session, $error) = Net::SNMP->session(
-    -hostname => $mp->opts->hostname,
-    -version => 'snmpv3',
-    -username => $mp->opts->username,
-    -authprotocol => $mp->opts->authprotocol,
-    -authpassword => $mp->opts->authpassphrase,
-    -privprotocol => $mp->opts->privprotocol,
-    -privpassword => $mp->opts->privpassphrase,
-);
-=cut
-
-#Open SNMP Session
-my ($session, $error) = Net::SNMP->session(
-    -hostname => $mp->opts->hostname,
-    -version => 'snmpv2c',
-    -community => $mp->opts->community,
-);
+my ($session, $error);
+if (defined($mp->opts->username) && defined($mp->opts->authpassword)) {
+    # SNMPv3 login
+    verb('SNMPv3 login');
+    if (!defined($mp->opts->privpassword)) {
+        verb('SNMPv3 AuthNoPriv login : %s, %s', $mp->opts->username, $mp->opts->authprotocol);
+        ($session, $error) = Net::SNMP->session(
+            -hostname => $mp->opts->hostname,
+            -version => 'snmpv3',
+            -username => $mp->opts->username,
+            -authprotocol => $mp->opts->authprotocol,
+            -authpassword => $mp->opts->authpassword,
+        );
+    } else {
+        verb('SNMPv3 AuthPriv login : %s, %s, %s', ${mp->opts->username}, ${mp->opts->authprotocol}, ${mp->opts->privprotocol});
+        ($session, $error) = Net::SNMP->session(
+            -hostname => $mp->opts->hostname,
+            -version => 'snmpv3',
+            -username => $mp->opts->username,
+            -authprotocol => $mp->opts->authprotocol,
+            -authpassword => $mp->opts->authpassword,
+            -privprotocol => $mp->opts->privprotocol,
+            -privpassword => $mp->opts->privpassword,
+        );
+    }
+} else {
+  verb('SNMP v2c login');
+  ($session, $error) = Net::SNMP->session(
+      -hostname => $mp->opts->hostname,
+      -version => 'snmpv2c',
+      -community => $mp->opts->community,
+  );
+}
 
 if (!defined($session)) {
     wrap_exit(UNKNOWN, $error)
@@ -432,6 +451,14 @@ sub parse_expire_date
         $date{'mday'} = $2;
     }
     return \%date;
+}
+
+sub verb
+{
+    my $t = shift;
+    if ($mp->opts->verbose) {
+      printf($t . "\n", @_);
+    }
 }
 
 sub wrap_exit

--- a/check_sophos_xg_license.pl
+++ b/check_sophos_xg_license.pl
@@ -175,7 +175,7 @@ foreach my $name (@licenses_included) {
     push(@licenses_to_check, $name);
 }
 
-#Open SNMP v3 Session 
+#Open SNMP v3 Session
 =begin comment
 my ($session, $error) = Net::SNMP->session(
     -hostname => $mp->opts->hostname,

--- a/check_sophos_xg_license.pl
+++ b/check_sophos_xg_license.pl
@@ -194,7 +194,7 @@ if (defined($mp->opts->username) && defined($mp->opts->authpassword)) {
             -authpassword => $mp->opts->authpassword,
         );
     } else {
-        verb('SNMPv3 AuthPriv login : %s, %s, %s', ${mp->opts->username}, ${mp->opts->authprotocol}, ${mp->opts->privprotocol});
+        verb('SNMPv3 AuthPriv login : %s, %s, %s', $mp->opts->username, $mp->opts->authprotocol, $mp->opts->privprotocol);
         ($session, $error) = Net::SNMP->session(
             -hostname => $mp->opts->hostname,
             -version => 'snmpv3',

--- a/check_sophos_xg_license.pl
+++ b/check_sophos_xg_license.pl
@@ -82,8 +82,36 @@ $mp->add_arg(
 
 $mp->add_arg(
     spec => 'hostname|H=s',
-    help => '',
+    help => 'Hostname or IP of the device with SNMP access enabled',
     required => 1
+);
+
+$mp->add_arg(
+    spec     => 'username|u=s',
+    help     => 'security name',
+    # required => 1
+);
+
+$mp->add_arg(
+    spec     => 'authprotocol|a=s',
+    help     => 'Authentication protocol (MD5|SHA|SHA-224|SHA-256|SHA-384|SHA-512)',
+    # required => 1
+);
+
+$mp->add_arg(
+    spec     => 'authpassphrase|A=s',
+    help     => 'Authentication protocol pass phrase',
+    # required => 1
+);
+
+$mp->add_arg(
+    spec     => 'privprotocol|x=s',
+    help     => 'Privacy protocol (DES|AES)',
+);
+
+$mp->add_arg(
+    spec     => 'privpassphrase|X=s',
+    help     => 'privacy protocol pass phrase',
 );
 
 $mp->add_arg(
@@ -146,6 +174,19 @@ foreach my $name (@licenses_included) {
     }
     push(@licenses_to_check, $name);
 }
+
+#Open SNMP v3 Session 
+=begin comment
+my ($session, $error) = Net::SNMP->session(
+    -hostname => $mp->opts->hostname,
+    -version => 'snmpv3',
+    -username => $mp->opts->username,
+    -authprotocol => $mp->opts->authprotocol,
+    -authpassword => $mp->opts->authpassphrase,
+    -privprotocol => $mp->opts->privprotocol,
+    -privpassword => $mp->opts->privpassphrase,
+);
+=cut
 
 #Open SNMP Session
 my ($session, $error) = Net::SNMP->session(

--- a/check_sophos_xg_memory.pl
+++ b/check_sophos_xg_memory.pl
@@ -68,31 +68,30 @@ $mp->add_arg(
 );
 
 $mp->add_arg(
-    spec     => 'username|u=s',
-    help     => 'security name',
-    # required => 1
+    spec => 'username|u=s',
+    help => 'Username for SNMPv3',
 );
 
 $mp->add_arg(
-    spec     => 'authprotocol|a=s',
-    help     => 'Authentication protocol (MD5|SHA|SHA-224|SHA-256|SHA-384|SHA-512)',
-    # required => 1
+    spec => 'authpassword|A=s',
+    help => 'Authentication protocol password',
 );
 
 $mp->add_arg(
-    spec     => 'authpassphrase|A=s',
-    help     => 'Authentication protocol pass phrase',
-    # required => 1
+    spec    => 'authprotocol|a=s',
+    help    => 'Authentication protocol: MD5, SHA, SHA-224, SHA-256, SHA-384, SHA-512 (Default: MD5)',
+    default => 'md5',
 );
 
 $mp->add_arg(
-    spec     => 'privprotocol|x=s',
-    help     => 'Privacy protocol (DES|AES)',
+    spec => 'privpassword|X=s',
+    help => 'privacy protocol password',
 );
 
 $mp->add_arg(
-    spec     => 'privpassphrase|X=s',
-    help     => 'privacy protocol pass phrase',
+    spec    => 'privprotocol|x=s',
+    help    => 'Privacy protocol: DES, AES (Default: DES)',
+    default => 'des',
 );
 
 $mp->add_arg(
@@ -121,27 +120,47 @@ $mp->add_arg(
     default => 0,
 );
 
+$mp->add_arg(
+    spec    => 'verbose',
+    help    => 'Print verbose/debug information',
+    default => 0,
+);
+
 $mp->getopts;
 
-#Open SNMP v3 Session
-=begin comment
-my ($session, $error) = Net::SNMP->session(
-    -hostname => $mp->opts->hostname,
-    -version => 'snmpv3',
-    -username => $mp->opts->username,
-    -authprotocol => $mp->opts->authprotocol,
-    -authpassword => $mp->opts->authpassphrase,
-    -privprotocol => $mp->opts->privprotocol,
-    -privpassword => $mp->opts->privpassphrase,
-);
-=cut
-
-#Open SNMP Session
-my ($session, $error) = Net::SNMP->session(
-    -hostname => $mp->opts->hostname,
-    -version => 'snmpv2c',
-    -community => $mp->opts->community,
-);
+my ($session, $error);
+if (defined($mp->opts->username) && defined($mp->opts->authpassword)) {
+    # SNMPv3 login
+    verb('SNMPv3 login');
+    if (!defined($mp->opts->privpassword)) {
+        verb('SNMPv3 AuthNoPriv login : %s, %s', $mp->opts->username, $mp->opts->authprotocol);
+        ($session, $error) = Net::SNMP->session(
+            -hostname => $mp->opts->hostname,
+            -version => 'snmpv3',
+            -username => $mp->opts->username,
+            -authprotocol => $mp->opts->authprotocol,
+            -authpassword => $mp->opts->authpassword,
+        );
+    } else {
+        verb('SNMPv3 AuthPriv login : %s, %s, %s', ${mp->opts->username}, ${mp->opts->authprotocol}, ${mp->opts->privprotocol});
+        ($session, $error) = Net::SNMP->session(
+            -hostname => $mp->opts->hostname,
+            -version => 'snmpv3',
+            -username => $mp->opts->username,
+            -authprotocol => $mp->opts->authprotocol,
+            -authpassword => $mp->opts->authpassword,
+            -privprotocol => $mp->opts->privprotocol,
+            -privpassword => $mp->opts->privpassword,
+        );
+    }
+} else {
+  verb('SNMP v2c login');
+  ($session, $error) = Net::SNMP->session(
+      -hostname => $mp->opts->hostname,
+      -version => 'snmpv2c',
+      -community => $mp->opts->community,
+  );
+}
 
 if (!defined($session)) {
     wrap_exit(UNKNOWN, $error)
@@ -342,6 +361,14 @@ sub check_memory
                 $capacity_usage,
             )
         );
+    }
+}
+
+sub verb
+{
+    my $t = shift;
+    if ($mp->opts->verbose) {
+      printf($t . "\n", @_);
     }
 }
 

--- a/check_sophos_xg_memory.pl
+++ b/check_sophos_xg_memory.pl
@@ -68,6 +68,34 @@ $mp->add_arg(
 );
 
 $mp->add_arg(
+    spec     => 'username|u=s',
+    help     => 'security name',
+    # required => 1
+);
+
+$mp->add_arg(
+    spec     => 'authprotocol|a=s',
+    help     => 'Authentication protocol (MD5|SHA|SHA-224|SHA-256|SHA-384|SHA-512)',
+    # required => 1
+);
+
+$mp->add_arg(
+    spec     => 'authpassphrase|A=s',
+    help     => 'Authentication protocol pass phrase',
+    # required => 1
+);
+
+$mp->add_arg(
+    spec     => 'privprotocol|x=s',
+    help     => 'Privacy protocol (DES|AES)',
+);
+
+$mp->add_arg(
+    spec     => 'privpassphrase|X=s',
+    help     => 'privacy protocol pass phrase',
+);
+
+$mp->add_arg(
     spec => 'memory-warning=s',
     help => 'Allowed values are % of capacity or value in MB (Default: 80% or 20% if --free is set)',
 );
@@ -94,6 +122,19 @@ $mp->add_arg(
 );
 
 $mp->getopts;
+
+#Open SNMP v3 Session 
+=begin comment
+my ($session, $error) = Net::SNMP->session(
+    -hostname => $mp->opts->hostname,
+    -version => 'snmpv3',
+    -username => $mp->opts->username,
+    -authprotocol => $mp->opts->authprotocol,
+    -authpassword => $mp->opts->authpassphrase,
+    -privprotocol => $mp->opts->privprotocol,
+    -privpassword => $mp->opts->privpassphrase,
+);
+=cut
 
 #Open SNMP Session
 my ($session, $error) = Net::SNMP->session(

--- a/check_sophos_xg_memory.pl
+++ b/check_sophos_xg_memory.pl
@@ -123,7 +123,7 @@ $mp->add_arg(
 
 $mp->getopts;
 
-#Open SNMP v3 Session 
+#Open SNMP v3 Session
 =begin comment
 my ($session, $error) = Net::SNMP->session(
     -hostname => $mp->opts->hostname,

--- a/check_sophos_xg_memory.pl
+++ b/check_sophos_xg_memory.pl
@@ -142,7 +142,7 @@ if (defined($mp->opts->username) && defined($mp->opts->authpassword)) {
             -authpassword => $mp->opts->authpassword,
         );
     } else {
-        verb('SNMPv3 AuthPriv login : %s, %s, %s', ${mp->opts->username}, ${mp->opts->authprotocol}, ${mp->opts->privprotocol});
+        verb('SNMPv3 AuthPriv login : %s, %s, %s', $mp->opts->username, $mp->opts->authprotocol, $mp->opts->privprotocol);
         ($session, $error) = Net::SNMP->session(
             -hostname => $mp->opts->hostname,
             -version => 'snmpv3',

--- a/check_sophos_xg_service.pl
+++ b/check_sophos_xg_service.pl
@@ -165,8 +165,36 @@ $mp->add_arg(
 
 $mp->add_arg(
     spec => 'hostname|H=s',
-    help => '',
+    help => 'Hostname or IP of the device with SNMP access enabled',
     required => 1
+);
+
+$mp->add_arg(
+    spec     => 'username|u=s',
+    help     => 'security name',
+    # required => 1
+);
+
+$mp->add_arg(
+    spec     => 'authprotocol|a=s',
+    help     => 'Authentication protocol (MD5|SHA|SHA-224|SHA-256|SHA-384|SHA-512)',
+    # required => 1
+);
+
+$mp->add_arg(
+    spec     => 'authpassphrase|A=s',
+    help     => 'Authentication protocol pass phrase',
+    # required => 1
+);
+
+$mp->add_arg(
+    spec     => 'privprotocol|x=s',
+    help     => 'Privacy protocol (DES|AES)',
+);
+
+$mp->add_arg(
+    spec     => 'privpassphrase|X=s',
+    help     => 'privacy protocol pass phrase',
 );
 
 $mp->add_arg(
@@ -245,7 +273,20 @@ foreach my $name (@services_included) {
     push(@services_to_check, $name);
 }
 
-#Open SNMP Session
+#Open SNMP v3 Session 
+=begin comment
+my ($session, $error) = Net::SNMP->session(
+    -hostname => $mp->opts->hostname,
+    -version => 'snmpv3',
+    -username => $mp->opts->username,
+    -authprotocol => $mp->opts->authprotocol,
+    -authpassword => $mp->opts->authpassphrase,
+    -privprotocol => $mp->opts->privprotocol,
+    -privpassword => $mp->opts->privpassphrase,
+);
+=cut
+
+#Open SNMP v2 Session
 my ($session, $error) = Net::SNMP->session(
     -hostname => $mp->opts->hostname,
     -version => 'snmpv2c',

--- a/check_sophos_xg_service.pl
+++ b/check_sophos_xg_service.pl
@@ -152,9 +152,9 @@ $parser->parse_string_document($extra_doc);
 
 my $mp = Monitoring::Plugin->new(
     shortname => "Sophos XG services",
-    usage => '',
-    version => VERSION,
-    extra => $extra_doc_output,
+    usage     => '',
+    version   => VERSION,
+    extra     => $extra_doc_output,
 );
 
 $mp->add_arg(
@@ -164,37 +164,36 @@ $mp->add_arg(
 );
 
 $mp->add_arg(
-    spec => 'hostname|H=s',
-    help => 'Hostname or IP of the device with SNMP access enabled',
+    spec     => 'hostname|H=s',
+    help     => 'Hostname or IP of the device with SNMP access enabled',
     required => 1
 );
 
 $mp->add_arg(
-    spec     => 'username|u=s',
-    help     => 'security name',
-    # required => 1
+    spec => 'username|u=s',
+    help => 'Username for SNMPv3',
 );
 
 $mp->add_arg(
-    spec     => 'authprotocol|a=s',
-    help     => 'Authentication protocol (MD5|SHA|SHA-224|SHA-256|SHA-384|SHA-512)',
-    # required => 1
+    spec => 'authpassword|A=s',
+    help => 'Authentication protocol password',
 );
 
 $mp->add_arg(
-    spec     => 'authpassphrase|A=s',
-    help     => 'Authentication protocol pass phrase',
-    # required => 1
+    spec    => 'authprotocol|a=s',
+    help    => 'Authentication protocol: MD5, SHA, SHA-224, SHA-256, SHA-384, SHA-512 (Default: MD5)',
+    default => 'md5',
 );
 
 $mp->add_arg(
-    spec     => 'privprotocol|x=s',
-    help     => 'Privacy protocol (DES|AES)',
+    spec => 'privpassword|X=s',
+    help => 'privacy protocol password',
 );
 
 $mp->add_arg(
-    spec     => 'privpassphrase|X=s',
-    help     => 'privacy protocol pass phrase',
+    spec    => 'privprotocol|x=s',
+    help    => 'Privacy protocol: DES, AES (Default: DES)',
+    default => 'des',
 );
 
 $mp->add_arg(
@@ -242,6 +241,12 @@ $mp->add_arg(
     default => ['running'],
 );
 
+$mp->add_arg(
+    spec    => 'verbose',
+    help    => 'Print verbose/debug information',
+    default => 0,
+);
+
 $mp->getopts;
 
 my @services_included;
@@ -273,25 +278,39 @@ foreach my $name (@services_included) {
     push(@services_to_check, $name);
 }
 
-#Open SNMP v3 Session
-=begin comment
-my ($session, $error) = Net::SNMP->session(
-    -hostname => $mp->opts->hostname,
-    -version => 'snmpv3',
-    -username => $mp->opts->username,
-    -authprotocol => $mp->opts->authprotocol,
-    -authpassword => $mp->opts->authpassphrase,
-    -privprotocol => $mp->opts->privprotocol,
-    -privpassword => $mp->opts->privpassphrase,
-);
-=cut
-
-#Open SNMP v2 Session
-my ($session, $error) = Net::SNMP->session(
-    -hostname => $mp->opts->hostname,
-    -version => 'snmpv2c',
-    -community => $mp->opts->community,
-);
+my ($session, $error);
+if (defined($mp->opts->username) && defined($mp->opts->authpassword)) {
+    # SNMPv3 login
+    verb('SNMPv3 login');
+    if (!defined($mp->opts->privpassword)) {
+        verb('SNMPv3 AuthNoPriv login : %s, %s', $mp->opts->username, $mp->opts->authprotocol);
+        ($session, $error) = Net::SNMP->session(
+            -hostname => $mp->opts->hostname,
+            -version => 'snmpv3',
+            -username => $mp->opts->username,
+            -authprotocol => $mp->opts->authprotocol,
+            -authpassword => $mp->opts->authpassword,
+        );
+    } else {
+        verb('SNMPv3 AuthPriv login : %s, %s, %s', ${mp->opts->username}, ${mp->opts->authprotocol}, ${mp->opts->privprotocol});
+        ($session, $error) = Net::SNMP->session(
+            -hostname => $mp->opts->hostname,
+            -version => 'snmpv3',
+            -username => $mp->opts->username,
+            -authprotocol => $mp->opts->authprotocol,
+            -authpassword => $mp->opts->authpassword,
+            -privprotocol => $mp->opts->privprotocol,
+            -privpassword => $mp->opts->privpassword,
+        );
+    }
+} else {
+  verb('SNMP v2c login');
+  ($session, $error) = Net::SNMP->session(
+      -hostname => $mp->opts->hostname,
+      -version => 'snmpv2c',
+      -community => $mp->opts->community,
+  );
+}
 
 if (!defined($session)) {
     wrap_exit(UNKNOWN, $error)
@@ -348,6 +367,14 @@ sub check
                 )
             );
         }
+    }
+}
+
+sub verb
+{
+    my $t = shift;
+    if ($mp->opts->verbose) {
+      printf($t . "\n", @_);
     }
 }
 

--- a/check_sophos_xg_service.pl
+++ b/check_sophos_xg_service.pl
@@ -273,7 +273,7 @@ foreach my $name (@services_included) {
     push(@services_to_check, $name);
 }
 
-#Open SNMP v3 Session 
+#Open SNMP v3 Session
 =begin comment
 my ($session, $error) = Net::SNMP->session(
     -hostname => $mp->opts->hostname,

--- a/check_sophos_xg_service.pl
+++ b/check_sophos_xg_service.pl
@@ -292,7 +292,7 @@ if (defined($mp->opts->username) && defined($mp->opts->authpassword)) {
             -authpassword => $mp->opts->authpassword,
         );
     } else {
-        verb('SNMPv3 AuthPriv login : %s, %s, %s', ${mp->opts->username}, ${mp->opts->authprotocol}, ${mp->opts->privprotocol});
+        verb('SNMPv3 AuthPriv login : %s, %s, %s', $mp->opts->username, $mp->opts->authprotocol, $mp->opts->privprotocol);
         ($session, $error) = Net::SNMP->session(
             -hostname => $mp->opts->hostname,
             -version => 'snmpv3',

--- a/check_sophos_xg_vpn.pl
+++ b/check_sophos_xg_vpn.pl
@@ -64,8 +64,36 @@ $mp->add_arg(
 
 $mp->add_arg(
     spec => 'hostname|H=s',
-    help => '',
+    help => 'Hostname or IP of the device with SNMP access enabled',
     required => 1
+);
+
+$mp->add_arg(
+    spec     => 'username|u=s',
+    help     => 'security name',
+    # required => 1
+);
+
+$mp->add_arg(
+    spec     => 'authprotocol|a=s',
+    help     => 'Authentication protocol (MD5|SHA|SHA-224|SHA-256|SHA-384|SHA-512)',
+    # required => 1
+);
+
+$mp->add_arg(
+    spec     => 'authpassphrase|A=s',
+    help     => 'Authentication protocol pass phrase',
+    # required => 1
+);
+
+$mp->add_arg(
+    spec     => 'privprotocol|x=s',
+    help     => 'Privacy protocol (DES|AES)',
+);
+
+$mp->add_arg(
+    spec     => 'privpassphrase|X=s',
+    help     => 'privacy protocol pass phrase',
 );
 
 $mp->add_arg(
@@ -91,7 +119,20 @@ $mp->add_arg(
 
 $mp->getopts;
 
-#Open SNMP Session
+#Open SNMP v3 Session 
+=begin comment
+my ($session, $error) = Net::SNMP->session(
+    -hostname => $mp->opts->hostname,
+    -version => 'snmpv3',
+    -username => $mp->opts->username,
+    -authprotocol => $mp->opts->authprotocol,
+    -authpassword => $mp->opts->authpassphrase,
+    -privprotocol => $mp->opts->privprotocol,
+    -privpassword => $mp->opts->privpassphrase,
+);
+=cut
+
+#Open SNMP v2 Session
 my ($session, $error) = Net::SNMP->session(
     -hostname => $mp->opts->hostname,
     -version => 'snmpv2c',

--- a/check_sophos_xg_vpn.pl
+++ b/check_sophos_xg_vpn.pl
@@ -119,7 +119,7 @@ $mp->add_arg(
 
 $mp->getopts;
 
-#Open SNMP v3 Session 
+#Open SNMP v3 Session
 =begin comment
 my ($session, $error) = Net::SNMP->session(
     -hostname => $mp->opts->hostname,

--- a/check_sophos_xg_vpn.pl
+++ b/check_sophos_xg_vpn.pl
@@ -63,37 +63,36 @@ $mp->add_arg(
 );
 
 $mp->add_arg(
-    spec => 'hostname|H=s',
-    help => 'Hostname or IP of the device with SNMP access enabled',
+    spec     => 'hostname|H=s',
+    help     => 'Hostname or IP of the device with SNMP access enabled',
     required => 1
 );
 
 $mp->add_arg(
-    spec     => 'username|u=s',
-    help     => 'security name',
-    # required => 1
+    spec => 'username|u=s',
+    help => 'Username for SNMPv3',
 );
 
 $mp->add_arg(
-    spec     => 'authprotocol|a=s',
-    help     => 'Authentication protocol (MD5|SHA|SHA-224|SHA-256|SHA-384|SHA-512)',
-    # required => 1
+    spec => 'authpassword|A=s',
+    help => 'Authentication protocol password',
 );
 
 $mp->add_arg(
-    spec     => 'authpassphrase|A=s',
-    help     => 'Authentication protocol pass phrase',
-    # required => 1
+    spec    => 'authprotocol|a=s',
+    help    => 'Authentication protocol: MD5, SHA, SHA-224, SHA-256, SHA-384, SHA-512 (Default: MD5)',
+    default => 'md5',
 );
 
 $mp->add_arg(
-    spec     => 'privprotocol|x=s',
-    help     => 'Privacy protocol (DES|AES)',
+    spec => 'privpassword|X=s',
+    help => 'privacy protocol password',
 );
 
 $mp->add_arg(
-    spec     => 'privpassphrase|X=s',
-    help     => 'privacy protocol pass phrase',
+    spec    => 'privprotocol|x=s',
+    help    => 'Privacy protocol: DES, AES (Default: DES)',
+    default => 'des',
 );
 
 $mp->add_arg(
@@ -117,27 +116,47 @@ $mp->add_arg(
     default => 0,
 );
 
+$mp->add_arg(
+    spec    => 'verbose',
+    help    => 'Print verbose/debug information',
+    default => 0,
+);
+
 $mp->getopts;
 
-#Open SNMP v3 Session
-=begin comment
-my ($session, $error) = Net::SNMP->session(
-    -hostname => $mp->opts->hostname,
-    -version => 'snmpv3',
-    -username => $mp->opts->username,
-    -authprotocol => $mp->opts->authprotocol,
-    -authpassword => $mp->opts->authpassphrase,
-    -privprotocol => $mp->opts->privprotocol,
-    -privpassword => $mp->opts->privpassphrase,
-);
-=cut
-
-#Open SNMP v2 Session
-my ($session, $error) = Net::SNMP->session(
-    -hostname => $mp->opts->hostname,
-    -version => 'snmpv2c',
-    -community => $mp->opts->community,
-);
+my ($session, $error);
+if (defined($mp->opts->username) && defined($mp->opts->authpassword)) {
+    # SNMPv3 login
+    verb('SNMPv3 login');
+    if (!defined($mp->opts->privpassword)) {
+        verb('SNMPv3 AuthNoPriv login : %s, %s', $mp->opts->username, $mp->opts->authprotocol);
+        ($session, $error) = Net::SNMP->session(
+            -hostname => $mp->opts->hostname,
+            -version => 'snmpv3',
+            -username => $mp->opts->username,
+            -authprotocol => $mp->opts->authprotocol,
+            -authpassword => $mp->opts->authpassword,
+        );
+    } else {
+        verb('SNMPv3 AuthPriv login : %s, %s, %s', ${mp->opts->username}, ${mp->opts->authprotocol}, ${mp->opts->privprotocol});
+        ($session, $error) = Net::SNMP->session(
+            -hostname => $mp->opts->hostname,
+            -version => 'snmpv3',
+            -username => $mp->opts->username,
+            -authprotocol => $mp->opts->authprotocol,
+            -authpassword => $mp->opts->authpassword,
+            -privprotocol => $mp->opts->privprotocol,
+            -privpassword => $mp->opts->privpassword,
+        );
+    }
+} else {
+  verb('SNMP v2c login');
+  ($session, $error) = Net::SNMP->session(
+      -hostname => $mp->opts->hostname,
+      -version => 'snmpv2c',
+      -community => $mp->opts->community,
+  );
+}
 
 if (!defined($session)) {
     wrap_exit(UNKNOWN, $error)
@@ -224,6 +243,14 @@ sub check
                 $mp->opts->name,
             )
         );
+    }
+}
+
+sub verb
+{
+    my $t = shift;
+    if ($mp->opts->verbose) {
+      printf($t . "\n", @_);
     }
 }
 

--- a/check_sophos_xg_vpn.pl
+++ b/check_sophos_xg_vpn.pl
@@ -138,7 +138,7 @@ if (defined($mp->opts->username) && defined($mp->opts->authpassword)) {
             -authpassword => $mp->opts->authpassword,
         );
     } else {
-        verb('SNMPv3 AuthPriv login : %s, %s, %s', ${mp->opts->username}, ${mp->opts->authprotocol}, ${mp->opts->privprotocol});
+        verb('SNMPv3 AuthPriv login : %s, %s, %s', $mp->opts->username, $mp->opts->authprotocol, $mp->opts->privprotocol);
         ($session, $error) = Net::SNMP->session(
             -hostname => $mp->opts->hostname,
             -version => 'snmpv3',


### PR DESCRIPTION
I wanted to work with the memory check file and i find it useful, thanks, but i needed to work with snmpv3. So i had to add more options for the version 3 of snmp.
I added the new configuration as a comment for all the other checks.
User will have just to uncomment the opening session of version 3 block and comment the version 2.